### PR TITLE
fix: fixed UI and content errors

### DIFF
--- a/src/sites/flashcards/Subtitle.tsx
+++ b/src/sites/flashcards/Subtitle.tsx
@@ -10,21 +10,20 @@ export const Subtitle = async () => {
   if (!user) {
     return (
       <h2 className={commonStyles}>
-        You can also{' '}
+        You are not logged in! You can{' '}
         <Link
           className="underline"
           href={'/auth/register'}
         >
           Register
         </Link>{' '}
-        and{' '}
+        or{' '}
         <Link
           className="underline"
           href={'/auth/login'}
         >
           Login
-        </Link>{' '}
-        but now it doesn&apos;t provide any features yet.
+        </Link>
       </h2>
     );
   }

--- a/src/sites/home/index.tsx
+++ b/src/sites/home/index.tsx
@@ -47,9 +47,9 @@ export const Home = () => {
           You can already learn and test your skills. Try it out now! <br />
           <Link
             className="underline"
-            href={'/demo'}
+            href="/flashcards"
           >
-            Learn and test!
+            Learn and test yourself!
           </Link>
         </p>
       </Section>

--- a/src/sites/home/sections/section.tsx
+++ b/src/sites/home/sections/section.tsx
@@ -1,4 +1,6 @@
-import { ReactNode } from 'react';
+'use client';
+
+import { type ReactNode, useState } from 'react';
 
 type Props = {
   variant?: 'primary' | 'secondary' | 'destructive';
@@ -9,9 +11,15 @@ type Props = {
 };
 
 export const Section = ({ variant = 'primary', title, isList = false, border, children }: Props) => {
+  const [hasUnderline] = useState(() => {
+    // Title has an underline unless it's equal to "Try
+    // Quickflip"
+    return !(title === 'Try QuickFlip!');
+  });
+
   return (
     <section className={`p-3 bg-${variant} text-${variant}-foreground ${border && 'border-[5px] border-black'}`}>
-      <h2 className="my-4 underline">{title}</h2>
+      <h2 className={`my-4 ${hasUnderline && 'underline'}`}>{title}</h2>
       {isList ? <ul className="flex flex-col gap-y-2 text-base sm:text-lg text-justify">{children}</ul> : <div className="flex flex-col gap-y-2 text-base sm:text-lg text-justify">{children}</div>}
     </section>
   );


### PR DESCRIPTION
Removed an underline from "Try QuickFlip!" headline, as it was confusing user's it was clickable. Changed a link href in "Learn and test!" to a proper /flashcards link instead of /demo wrongly placed earlier. Removed a text stating registration and login didn't provide any functionality.